### PR TITLE
フッターの調整・フィードバックフォームへのリンク追加

### DIFF
--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -3,3 +3,4 @@ footer
     p © 2022 ジロサウナー
     = link_to '利用規約', terms_path, class: "md:ml-4 block"
     = link_to 'プライバシーポリシー', privacy_policy_path, class: "md:ml-4 block"
+    = link_to '開発者Twitter', 'https://twitter.com/botcher_matsu', class: "md:ml-4 block"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -21,7 +21,7 @@ header
       li.mx-4.my-6.md:my-0.flex
         svg.h-6.w-6 fill="none" stroke="#FFFFFF" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
           path d=("M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z") stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-        = link_to 'フィードバック', '#', class: 'text-white ml-2 text-base hover:text-accent-yellow duration-500'
+        = link_to 'フィードバック', 'https://forms.gle/CEwKNJea4HA2z19k7', class: 'text-white ml-2 text-base hover:text-accent-yellow duration-500'
 
     ul.md:hidden.z-20.bg-main-blue.min-h-screen.w-3/5.absolute.top-0.-right-sidebar.shadow-2xl.transition-all.duration-300.ease-in.opacity-0 id='sp_list'
       svg.h-8.w-8.ml-auto.mt-3.mr-5.cursor-pointer id='close' fill="none" stroke="white" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
@@ -42,5 +42,5 @@ header
       li.absolute.right-10.top-60.flex
         svg.h-6.w-6 fill="none" stroke="#FFFFFF" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
           path d=("M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z") stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-        = link_to 'フィードバック', '#', class: 'text-white ml-2 text-base font-semibold hover:text-accent-yellow duration-500'
+        = link_to 'フィードバック', 'https://forms.gle/CEwKNJea4HA2z19k7', class: 'text-white ml-2 text-base font-semibold hover:text-accent-yellow duration-500'
 

--- a/app/views/static_pages/privacy_policy.html.slim
+++ b/app/views/static_pages/privacy_policy.html.slim
@@ -1,5 +1,5 @@
 - set_meta_tags title: 'プライバシーポリシー', noindex: true
-.container.mx-auto
+.container.mx-auto.mt-24
   section.bg-white.m-10.p-10.rounded-lg
     .h3.text-center.mb-5 プライバシーポリシー
     | ジロサウナ〜（以下，「当方」といいます。）は，本ウェブサイト上で提供するサービス（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。

--- a/app/views/static_pages/terms.html.slim
+++ b/app/views/static_pages/terms.html.slim
@@ -1,5 +1,5 @@
 - set_meta_tags title: '利用規約', noindex: true
-.container.mx-auto
+.container.mx-auto.mt-24
   section.bg-white.m-10.p-10.rounded-lg
     .h3.text-center.mb-5 利用規約
     | この利用規約（以下，「本規約」といいます。）は，ジロサウナ〜（以下，「当方」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。


### PR DESCRIPTION
## チケットへのリンク
#73 

## 実装内容
1. 利用規約とプライバシーポリシーのマージントップを調整する
2. フィードバックにリンクを追加する
3. 開発者Twitterを追加する

## 補足
1. フィードバックフォームは近いうちにオリジナルフォームにする

## できるようになること（ユーザ目線）
1. フィードバックが送れるようになる
2. リンクから開発者Twitterを閲覧できる

## できなくなること（ユーザ目線）
特になし

## 動作確認・テスト結果
リンクのみの追加なのでテストなし