### PR TITLE
ツイートボタンの作成

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -36,6 +36,7 @@ class MapsController < ApplicationController
     prefecture = geoapi_data['response']['location'][0]['prefecture']
     city = geoapi_data['response']['location'][0]['city']
     town = geoapi_data['response']['location'][0]['town']
-    area = "#{prefecture}#{city}#{town}"
+
+    "#{prefecture}#{city}#{town}"
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -9,6 +9,8 @@ class MapsController < ApplicationController
       @jiros = Jiro.all.within(1.5, origin: [@latitude, @longitude]).by_distance(origin: [@latitude, @longitude])
       @saunas = Sauna.all.within(1.5, origin: [@latitude, @longitude]).by_distance(origin: [@latitude, @longitude])
 
+      @area = search_area(@latitude, @longitude)
+
       gon.latitude = @latitude
       gon.longitude = @longitude
       gon.jiros = @jiros
@@ -25,5 +27,15 @@ class MapsController < ApplicationController
 
   def geo_params
     params.require(:q).permit(:latitude, :longitude)
+  end
+
+  def search_area(lat, long)
+    geoapi_url = "https://geoapi.heartrails.com/api/json?method=searchByGeoLocation&x=#{long}&y=#{lat}"
+    geoapi_page = URI.open(geoapi_url).read
+    geoapi_data = JSON.parse(geoapi_page)
+    prefecture = geoapi_data['response']['location'][0]['prefecture']
+    city = geoapi_data['response']['location'][0]['city']
+    town = geoapi_data['response']['location'][0]['town']
+    area = "#{prefecture}#{city}#{town}"
   end
 end

--- a/app/views/maps/_map.html.slim
+++ b/app/views/maps/_map.html.slim
@@ -6,5 +6,5 @@ section.relative.overflow-hidden
       => f.number_field :latitude, id: 'lat', step: '0.0000001', value: '', type: 'hidden'
       => f.number_field :longitude, id: 'lng', step: '0.0000001', value: '', type: 'hidden'
       .text-center.mt-10
-        => f.submit '周辺の二郎とサウナを探す', class: 'text-white bg-main-blue rounded-full hover:bg-dark-blue font-semibold text-sm px-5 py-2.5 text-center mr-2 mb-2 drop-shadow-md cursor-pointer'
+        => f.submit '周辺の二郎とサウナを探す', class: 'text-white bg-main-blue rounded-full hover:bg-dark-blue font-semibold text-sm px-5 py-2.5 text-center mr-2 mb-2 shadow-md cursor-pointer'
   script async="" defer="defer" src="https://maps.googleapis.com/maps/api/js?key=#{ENV['API_KEY']}&callback=initMap&libraries=places"

--- a/app/views/maps/search.html.slim
+++ b/app/views/maps/search.html.slim
@@ -5,11 +5,16 @@
     - unless @jiros.nil? && @saunas.nil?
       h2.my-10.font-semibold.text-3xl.text-center 二郎系ラーメン
       - if @jiros.present?
-        == render 'shared/shops', shops: @jiros 
+        = render 'shared/shops', shops: @jiros 
       - else
         p.text-center 近くの二郎系は見つかりませんでした
       h2.my-10.font-semibold.text-3xl.text-center 銭湯・サウナ
       - if @saunas.present?
-        == render 'shared/shops', shops: @saunas 
+        = render 'shared/shops', shops: @saunas 
       - else
         p.text-center 近くの銭湯・サウナは見つかりませんでした
+      .text-center
+        .space-x-2.inline-flex.items-center.my-10.bg-main-blue.text-white.rounded-full.hover:bg-dark-blue.font-semibold.text-sm.px-10.py-2.5.shadow-md.cursor-pointer
+          svg.w-6.h-6.text-white.fill-current viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
+            path d=("M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z") 
+          = link_to '場所を共有する', "https://twitter.com/share?url=#{request.url}/&text=近くの二郎とサウナが一瞬でみつかるサービス - ジロサウナ〜&hashtags=二郎,サウナ,サ飯", title: "#{@area}周辺のお店をみる", target: '_blank'

--- a/app/views/maps/search.html.slim
+++ b/app/views/maps/search.html.slim
@@ -14,7 +14,8 @@
       - else
         p.text-center 近くの銭湯・サウナは見つかりませんでした
       .text-center
-        .space-x-2.inline-flex.items-center.my-10.bg-main-blue.text-white.rounded-full.hover:bg-dark-blue.font-semibold.text-sm.px-10.py-2.5.shadow-md.cursor-pointer
-          svg.w-6.h-6.text-white.fill-current viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
-            path d=("M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z") 
-          = link_to '場所を共有する', "https://twitter.com/share?url=#{request.url}/&text=近くの二郎とサウナが一瞬でみつかるサービス - ジロサウナ〜&hashtags=二郎,サウナ,サ飯", title: "#{@area}周辺のお店をみる", target: '_blank'
+        = link_to "https://twitter.com/share?url=#{request.url}/&text=近くの二郎とサウナが一瞬でみつかるサービス - ジロサウナ〜&hashtags=二郎,サウナ,サ飯", title: "#{@area}周辺のお店をみる", target: '_blank' do
+          .space-x-2.inline-flex.items-center.my-10.bg-main-blue.text-white.rounded-full.hover:bg-dark-blue.font-semibold.text-sm.px-10.py-2.5.shadow-md.cursor-pointer
+            svg.w-6.h-6.text-white.fill-current viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
+              path d=("M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z") 
+            span 場所を共有する


### PR DESCRIPTION
## チケットへのリンク
#78 
## 実装内容
検索結果をシェアできるツイートボタンを作成

## 補足
```
def search_area(lat, long)
    geoapi_url = "https://geoapi.heartrails.com/api/json?method=searchByGeoLocation&x=#{long}&y=#{lat}"
    geoapi_page = URI.open(geoapi_url).read
    geoapi_data = JSON.parse(geoapi_page)
    prefecture = geoapi_data['response']['location'][0]['prefecture']
    city = geoapi_data['response']['location'][0]['city']
    town = geoapi_data['response']['location'][0]['town']

    "#{prefecture}#{city}#{town}"
  end
```
1. リンク先が何なのか？明確でないと共有ツイートを見たユーザーはリンクを開かないと考えたので、「東京都世田谷区喜多見周辺のお店」というタイトルにしてます
2. その際、住所取得は上記のような設計になっており、HeartRailsAPIという無料のAPIを叩いて緯度経度から逆ジオコーディングすることで住所を割り出しています

## できるようになること（ユーザ目線）
場所を共有できる

## できなくなること（ユーザ目線）
特になし

## 動作確認・テスト結果
https://gyazo.com/626bf431f30f694bd43a552b81197536