### PR TITLE
ツイート短縮URLを生成 #80

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ gem 'rails_admin', ['>= 3.0.0.beta2', '< 4']
 # SEO
 gem 'meta-tags'
 
+# Shorten URL
+gem 'shortener'
+
 gem 'rexml', '~> 3.2', '>= 3.2.5'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
+    shortener (0.8.2)
+      voight_kampff (~> 1.1.2)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -326,6 +328,8 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    voight_kampff (1.1.4)
+      rack (>= 1.4, < 3.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -388,6 +392,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  shortener
   slim-rails
   turbolinks (~> 5)
   tzinfo-data

--- a/app/views/maps/search.html.slim
+++ b/app/views/maps/search.html.slim
@@ -14,7 +14,7 @@
       - else
         p.text-center 近くの銭湯・サウナは見つかりませんでした
       .text-center
-        = link_to "https://twitter.com/share?url=#{request.url}/&text=近くの二郎とサウナが一瞬でみつかるサービス - ジロサウナ〜&hashtags=二郎,サウナ,サ飯", title: "#{@area}周辺のお店をみる", target: '_blank' do
+        = link_to "https://twitter.com/share?url=#{short_url(request.url)}/&text=近くの二郎とサウナが一瞬でみつかるサービス - ジロサウナ〜&hashtags=二郎,サウナ,サ飯", title: "#{@area}周辺のお店をみる", target: '_blank' do
           .space-x-2.inline-flex.items-center.my-10.bg-main-blue.text-white.rounded-full.hover:bg-dark-blue.font-semibold.text-sm.px-10.py-2.5.shadow-md.cursor-pointer
             svg.w-6.h-6.text-white.fill-current viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
               path d=("M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z") 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
   resources :jiros, only: %i[index show]
   resources :saunas, only: %i[index show]
   get 'maps', to: 'maps#search'
+  get '/:id' => "shortener/shortened_urls#show"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20220218041631_create_shortened_urls_table.rb
+++ b/db/migrate/20220218041631_create_shortened_urls_table.rb
@@ -1,0 +1,33 @@
+class CreateShortenedUrlsTable < ActiveRecord::Migration[4.2]
+  def change
+    create_table :shortened_urls do |t|
+      # we can link this to a user for interesting things
+      t.integer :owner_id
+      t.string :owner_type, limit: 20
+
+      # the real url that we will redirect to
+      t.text :url, null: false, length: 2083
+
+      # the unique key
+      t.string :unique_key, limit: 10, null: false
+
+      # a category to help categorize shortened urls
+      t.string :category
+
+      # how many times the link has been clicked
+      t.integer :use_count, null: false, default: 0
+
+      # valid until date for expirable urls
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+
+    # we will lookup the links in the db by key, urls and owners.
+    # also make sure the unique keys are actually unique
+    add_index :shortened_urls, :unique_key, unique: true
+    add_index :shortened_urls, :url, length: 2083
+    add_index :shortened_urls, [:owner_id, :owner_type]
+    add_index :shortened_urls, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_071720) do
+ActiveRecord::Schema.define(version: 2022_02_18_041631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,22 @@ ActiveRecord::Schema.define(version: 2022_01_19_071720) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "address"
     t.string "photo_reference"
+  end
+
+  create_table "shortened_urls", id: :serial, force: :cascade do |t|
+    t.integer "owner_id"
+    t.string "owner_type", limit: 20
+    t.text "url", null: false
+    t.string "unique_key", limit: 10, null: false
+    t.string "category"
+    t.integer "use_count", default: 0, null: false
+    t.datetime "expires_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["category"], name: "index_shortened_urls_on_category"
+    t.index ["owner_id", "owner_type"], name: "index_shortened_urls_on_owner_id_and_owner_type"
+    t.index ["unique_key"], name: "index_shortened_urls_on_unique_key", unique: true
+    t.index ["url"], name: "index_shortened_urls_on_url"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## チケットへのリンク
#80 

## 実装内容
検索結果ツイート時URLを短縮する（TwitterにはURLの長さに制限があるため）

## 補足
gem shortener(https://github.com/jpmcgrath/shortener/)を使用した

## できるようになること（ユーザ目線）
ツイートできるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認・テスト結果
<img width="570" alt="スクリーンショット 2022-02-18 13 23 55" src="https://user-images.githubusercontent.com/63547176/154617241-a802baba-de3b-49b8-ba94-4b50d8a2840e.png">

短縮系で表示されていることを確認