### PR TITLE
add: エラーメッセージを追加 #62

### DIFF
--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -118,7 +118,7 @@ function initMap() {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
-          const pos = {
+          var pos = {
             lat: position.coords.latitude,
             lng: position.coords.longitude,
           };
@@ -129,9 +129,22 @@ function initMap() {
             icon: '/assets/current_icon.png'
           });
         },
+        (error) => {
+          var errorInfo = [
+            '原因不明のエラーが発生しました',
+            '位置情報の取得が許可されませんでした。設定を確認してください。',
+            '電波状況などで位置情報が取得できませんでした',
+            '位置情報の取得に時間がかかり過ぎてタイムアウトしました'
+          ];
+          var errorNum = error.code;
+
+          var errorMessage = errorInfo[errorNum]
+
+          alert(errorMessage);
+        }
       );
     } else {
-      alert('あなたの端末では、現在位置を取得できません。') ;
+      window.alert('お使いの端末では対応しておりません...。');
     }
   });
 


### PR DESCRIPTION
## チケットへのリンク
#62 

## 実装内容
「現在地へ移動する」ボタンを押した時、位置情報の取得が許可されていない場合のエラーメッセージをアラートで出す。

## 補足
参考：https://syncer.jp/how-to-use-geolocation-api
元々、GeoLocation APIに対応しているかどうかしか条件分岐していなかった。
Geolocation APIに対応しているが、位置情報の取得は許可されていない場合のコードを追加した

## できるようになること（ユーザ目線）
位置情報の取得は許可されていない場合アラートが出て原因がわかる

## できなくなること（ユーザ目線）
特になし

## 動作確認・テスト結果
<img width="640" alt="image" src="https://user-images.githubusercontent.com/63547176/154658097-7b5c44d3-7722-4f7c-a0a7-46e0b0ceecff.png">

